### PR TITLE
[ADD] Tags to Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ After the docker-compose built is ready, you need to configure the Django app an
 Log in to the Django container to apply the migrations. From your terminal, run this command.
 
 ```bash
-docker exec -it Django bash
+docker exec -it django bash
 ```
 
 Run the migrations. (If something goes wrong, try **python manage.py makemigrations** first)

--- a/django/rest/settings.py
+++ b/django/rest/settings.py
@@ -146,6 +146,8 @@ MEDIA_URL = "/media/"
 # Extra places for collectstatic to find static files.
 STATICFILES_DIRS = ()
 
+DEFAULT_AUTO_FIELD='django.db.models.AutoField'
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/odoo/document_ocr/__manifest__.py
+++ b/odoo/document_ocr/__manifest__.py
@@ -13,6 +13,7 @@
     "data": [
         'security/ir.model.access.csv',
         'data/ir_cron_data.xml',
+        'data/document_data.xml',
         'views/document.xml',
         'views/ocr_connector_views.xml',
         'views/res_config_settings_views.xml',

--- a/odoo/document_ocr/data/document_data.xml
+++ b/odoo/document_ocr/data/document_data.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <!-- OCR Workspace -->
+        <record id="documents_ocr_folder" model="documents.folder">
+            <field name="name">OCR</field>
+            <field name="ocr_sync">True</field>
+            <field name="sequence">1</field>
+        </record>
+
+        <!-- Facets -->
+        <record id="ocr_documents" model="documents.facet">
+            <field name="name">Documents OCR</field>
+            <field name="sequence">1</field>
+            <field name="folder_id" ref="documents_ocr_folder"/>
+        </record>
+
+        <!-- Tags -->
+        <record id="documents_ocr_sent_tag" model="documents.tag">
+            <field name="name">Sent</field>
+            <field name="folder_id" ref="documents_ocr_folder"/>
+            <field name="facet_id" ref="ocr_documents"/>
+            <field name="sequence">5</field>
+        </record>
+
+        <record id="documents_ocr_processed_tag" model="documents.tag">
+            <field name="name">Processed</field>
+            <field name="folder_id" ref="documents_ocr_folder"/>
+            <field name="facet_id" ref="ocr_documents"/>
+            <field name="sequence">5</field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
Tag documents as 'Sent' and 'Processed' depending on the status of the document.

Whenever a document is sent to the external service to be processed, it is tagged as 'Sent'. When an answer is received (means ocr_text field has any value) the document is tagged as 'Processed'.